### PR TITLE
Upgraded `renderObject.parent` object to use `RenderObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.1
+
+* Upgraded `renderObject.parent` object to use `RenderObject` instead of the deprecated `AbstractNode`. This ensures compatibility and resolves deprecation Flutter v3.12.0-4.0.pre warnings.
+
 ## 3.4.0
 
 * BugFix

--- a/lib/src/internal/columns_layout_child.dart
+++ b/lib/src/internal/columns_layout_child.dart
@@ -18,10 +18,10 @@ class ColumnsLayoutChild<DATA>
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is ColumnsLayoutParentData);
     final ColumnsLayoutParentData parentData =
-        renderObject.parentData! as ColumnsLayoutParentData;
+    renderObject.parentData! as ColumnsLayoutParentData;
     if (index != parentData.index) {
       parentData.index = index;
-      final AbstractNode? targetParent = renderObject.parent;
+      final RenderObject? targetParent = renderObject.parent;
       if (targetParent is RenderObject) {
         targetParent.markNeedsLayout();
       }

--- a/lib/src/internal/rows_layout_child.dart
+++ b/lib/src/internal/rows_layout_child.dart
@@ -19,11 +19,11 @@ class RowsLayoutChild extends ParentDataWidget<RowsLayoutParentData> {
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is RowsLayoutParentData);
     final RowsLayoutParentData parentData =
-        renderObject.parentData! as RowsLayoutParentData;
+    renderObject.parentData! as RowsLayoutParentData;
     if (index != parentData.index || last != parentData.last) {
       parentData.index = index;
       parentData.last = last;
-      final AbstractNode? targetParent = renderObject.parent;
+      final RenderObject? targetParent = renderObject.parent;
       if (targetParent is RenderObject) {
         targetParent.markNeedsLayout();
       }

--- a/lib/src/internal/table_layout_child.dart
+++ b/lib/src/internal/table_layout_child.dart
@@ -111,10 +111,10 @@ class TableLayoutChild<DATA> extends ParentDataWidget<TableLayoutParentData> {
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is TableLayoutParentData);
     final TableLayoutParentData parentData =
-        renderObject.parentData! as TableLayoutParentData;
+    renderObject.parentData! as TableLayoutParentData;
     if (id != parentData.id) {
       parentData.id = id;
-      final AbstractNode? targetParent = renderObject.parent;
+      final RenderObject? targetParent = renderObject.parent;
       if (targetParent is RenderObject) {
         targetParent.markNeedsLayout();
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: davi
 description: A full customized dataview that builds the cells on demand. Focused on Web/Desktop Applications. Bidirectional scroll bars. (DataTable, Data Table, Data View)
-version: 3.4.0
+version: 3.4.1
 repository: https://github.com/caduandrade/davi_flutter
 
 environment:


### PR DESCRIPTION
Upgraded `renderObject.parent` object to use `RenderObject` instead of the deprecated `AbstractNode`. 


This ensures compatibility and resolves deprecation Flutter v3.12.0-4.0.pre warnings.


This PR fixes such exceptions:

```
../../.pub-cache/hosted/pub.dev/davi-3.4.0/lib/src/internal/table_layout_child.dart:119:22: Error: The method 'markNeedsLayout' isn't defined for the class 'AbstractNode?'.
 - 'AbstractNode' is from 'package:flutter/src/foundation/node.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
Try correcting the name to the name of an existing method, or defining a method named 'markNeedsLayout'.
        targetParent.markNeedsLayout();
                     ^^^^^^^^^^^^^^^
../../.pub-cache/hosted/pub.dev/davi-3.4.0/lib/src/internal/rows_layout_child.dart:26:55: Error: A value of type 'RenderObject?' can't be assigned to a variable of type 'AbstractNode?'.
 - 'RenderObject' is from 'package:flutter/src/rendering/object.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
 - 'AbstractNode' is from 'package:flutter/src/foundation/node.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
      final AbstractNode? targetParent = renderObject.parent;
```